### PR TITLE
Scoreboard - added route to show scoreboard

### DIFF
--- a/lib/lita/handlers/espn_fantasy_football.rb
+++ b/lib/lita/handlers/espn_fantasy_football.rb
@@ -41,7 +41,7 @@ module Lita
 
         Lita.logger.debug("#{ response.user.name } requested scoreboard for week '#{ week }'")
         matchups = espn_scoreboard_scrape(week)
-        table = Terminal::Table.new(:headings => matchsup["headers"], :rows => matchups["rows"])
+        table = Terminal::Table.new(:headings => matchups["headers"], :rows => matchups["rows"])
         response.reply("```\n#{ table }\n```")
       end
 

--- a/lib/lita/handlers/espn_fantasy_football.rb
+++ b/lib/lita/handlers/espn_fantasy_football.rb
@@ -40,7 +40,7 @@ module Lita
         end
 
         Lita.logger.debug("#{ response.user.name } requested scoreboard for week '#{ week }'")
-        matchups = espn_scoreboard_scrape(week).map do |m|
+        matchups = espn_scoreboard_scrape(week)
         table = Terminal::Table.new(:headings => matchsup["headers"], :rows => matchups["rows"])
         response.reply("```\n#{ table }\n```")
       end


### PR DESCRIPTION
This route shows all matchups in the league for a given week.

TODO:
- allow user to scoreboard themselves (e.g. `scoreboard me`)
- allow user to scoreboard any slack user (e.g. `scoreboard @lombardi`)
